### PR TITLE
Modernize PHP Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 7.2
-          - 7.3
-          - 7.4
           - 8.0
           - 8.1
           - 8.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
+          - 8.4
         dependencies:
           - lowest
           - highest

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A simple nonblocking server dedicated to websockets.",
     "type": "library",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "react/socket": "^1.0",
         "ratchet/rfc6455": "^0.3",
         "guzzlehttp/psr7": "^1.9 || ^2.5"

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.23 || ^9"
+        "phpunit/phpunit": "^9.6.20"
     }
 }


### PR DESCRIPTION
This merge request modernizes the library by updating PHP and PHPUnit support and updating GitHub Actions CI.

## Changes

- Update PHPUnit to version 9.6.20 for PHP 8.4 compatibility
- Add PHP 8.3 and 8.4 to the GitHub Actions CI test matrix

## Breaking Changes

- **PHP 7.x is no longer supported** - minimum PHP version is now 8.0